### PR TITLE
Fix mention of Serde in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,5 +20,5 @@ at your option.
 ### Contribution
 
 Unless you explicitly state otherwise, any contribution intentionally submitted
-for inclusion in Serde by you, as defined in the Apache-2.0 license, shall be
+for inclusion in tokio-openssl by you, as defined in the Apache-2.0 license, shall be
 dual licensed as above, without any additional terms or conditions.


### PR DESCRIPTION
The README's “Contribution” section currently talks about Serde. This trivial PR changes it to tokio-openssl.